### PR TITLE
Fix line break conversion on unicode system

### DIFF
--- a/zcl_json.clas.abap
+++ b/zcl_json.clas.abap
@@ -205,10 +205,9 @@ method call_conversion_exit.
 
 method CLASS_CONSTRUCTOR.
   "// Initialize static attributes
-  field-symbols <x> type x.
+  cr = cl_abap_char_utilities=>cr_lf+0(1).
+  lf = cl_abap_char_utilities=>cr_lf+1(1).
 
-  assign cr to <x> casting. <x> = 13.
-  assign lf to <x> casting. <x> = 10.
 endmethod.
 
 
@@ -883,13 +882,7 @@ endmethod.
 
 
 method ESCAPE_STRING.
-  data: cr type c,
-        lf type c.
-
   field-symbols <x> type x.
-
-  assign cr to <x> casting. <x> = 13.
-  assign lf to <x> casting. <x> = 10.
 
   result = input.
   replace regex '\s+$' in result with ''.

--- a/zcl_json.clas.testclasses.abap
+++ b/zcl_json.clas.testclasses.abap
@@ -6,6 +6,7 @@ class ltcl_test definition final
   private section.
 
     methods unicode for testing.
+    METHODS replace_crlf_linebreak FOR TESTING RAISING cx_static_check.
 
 endclass.
 
@@ -35,6 +36,32 @@ class ltcl_test implementation.
     cl_abap_unit_assert=>assert_equals(
       act = ls_act
       exp = ls_exp ).
+
+  endmethod.
+  
+  method replace_crlf_linebreak.
+     types:
+      begin of ty_one_string,
+        str type string,
+      end of ty_one_string.
+
+    data ls_input type ty_one_string.
+    data lo_cut type ref to zcl_pmc_json.
+    create object lo_cut.
+
+    ls_input-str = 'Line1' && cl_abap_char_utilities=>cr_lf && 'Line2'.
+
+    lo_cut->encode(
+      EXPORTING
+        value = ls_input
+      RECEIVING
+        json  = data(lv_json_result)
+    ).
+
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_json_result
+      exp = '{"str": "Line1\r\nLine2"}' ).
 
   endmethod.
 


### PR DESCRIPTION
Hi @sbcgua ,

I am using zcl_json on our unicode system and line breaks were not converted into \r\n, resulting in invalid json. I fixed it by using SAPs cl_abap_char_utilities=>cr_lf instead of manually creating the Character codes.

I also wrote a test for this.